### PR TITLE
Fix for central.maven.org not resolving anymore

### DIFF
--- a/security-gateway/uaa/Dockerfile
+++ b/security-gateway/uaa/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 # Download the UAA Web Application Archive from Maven Central
 ENV UAA_VERSION=4.30.0
 RUN wget \
-      http://central.maven.org/maven2/org/cloudfoundry/identity/cloudfoundry-identity-uaa/$UAA_VERSION/cloudfoundry-identity-uaa-$UAA_VERSION.war \
+      https://repo1.maven.org/maven2/org/cloudfoundry/identity/cloudfoundry-identity-uaa/$UAA_VERSION/cloudfoundry-identity-uaa-$UAA_VERSION.war \
       -O $CATALINA_HOME/webapps/uaa.war
 
 # Configure the UAA


### PR DESCRIPTION
Symptom:
```
spring-cloud-gateway-demo/security-gateway$ ./build.sh
...
Step 4/14 : RUN wget       http://central.maven.org/maven2/org/cloudfoundry/identity/cloudfoundry-identity-uaa/$UAA_VERSION/cloudfoundry-identity-uaa-$UAA_VERSION.war       -
O $CATALINA_HOME/webapps/uaa.war
 ---> Running in 98463173529d
--2020-04-16 11:44:28--  http://central.maven.org/maven2/org/cloudfoundry/identity/cloudfoundry-identity-uaa/4.30.0/cloudfoundry-identity-uaa-4.30.0.war
Resolving central.maven.org (central.maven.org)... failed: Name or service not known.
wget: unable to resolve host address ‘central.maven.org’
...
```

Note: [Latest releases of CF UAA (>4.30.0) are not available on Maven Central](https://github.com/cloudfoundry/uaa/issues/1075).